### PR TITLE
Add support for glob syntax. Directories assumes all files.

### DIFF
--- a/lib/objects_parser.rb
+++ b/lib/objects_parser.rb
@@ -14,8 +14,11 @@ class ObjectsParser
   def folder_parse
     # create the output text file or delete contents of existing file
     File.open(output_file, 'w') {}
-    Dir.each_child(data_path) do |f|
-      file = File.join(data_path, f)
+
+    data_path.concat('/*') if File.directory?(data_path)
+
+    Dir.glob(data_path).each do |f|
+      file = File.join(f)
       send(method, file)
     end
   end

--- a/lib/option_parser.rb
+++ b/lib/option_parser.rb
@@ -29,7 +29,7 @@ class OptionParser
         options[:output_file_path] = output_file_path
       end
 
-      opts.on('-f', '--folder DATA FOLDER PATH', 'Default is process_data') do |json_folder_path|
+      opts.on('-f', '--folder DATA FOLDER PATH', 'Default is process_data. Supports glob syntax.') do |json_folder_path|
         options[:json_folder_path] = json_folder_path
       end
 


### PR DESCRIPTION
Implements #4. This commit adds support for glob syntax instead of combining directories or specific files. If a directory is passed as argument the glob star (`*`) will be added. Example usages from the repository:

```sh
# All files in process_data
bin/parse -f process_data/

# Also all files in process_Data
bin/parse -f "process_data/*"

# All files ending with .jsonl
bin/parse -f "process_data/*.jsonl"
```

As of now the argument must be quoted to avoid being expanded by the shell. Maybe it would be a better idea to support files as input and let the shell expand. That way `folder_parse` could be removed and instead only call `extract_unique_id` for each argument to `bin/parser`.

Since this isn't the wait it works now I didn't want to change too much. Feel free to reject the PR and look for an alternative solution. :)

Happy Hacktoberfest!