### PR TITLE
Two new methods for analyzing JSONL's

### DIFF
--- a/lib/option_parser.rb
+++ b/lib/option_parser.rb
@@ -7,7 +7,9 @@ class OptionParser
     options = {
       files: ARGV,
       output_file_path: 'output.txt',
-      method: 'extract_unique_id'
+      # method: 'extract_unique_id'
+      # method: 'property_survey'
+      method: 'deep_key_search'
     }
 
     opt_parser = OptionParser.new do |opts|

--- a/lib/option_parser.rb
+++ b/lib/option_parser.rb
@@ -7,9 +7,9 @@ class OptionParser
     options = {
       files: ARGV,
       output_file_path: 'output.txt',
-      # method: 'extract_unique_id'
+      method: 'extract_unique_id'
       # method: 'property_survey'
-      method: 'deep_key_search'
+      # method: 'deep_key_search'
     }
 
     opt_parser = OptionParser.new do |opts|


### PR DESCRIPTION
Created two new methods, ObjectsParser#property_survey, whose text output is a list of top-level properties, each listed with the number of JSON objects in which it appears, and ObjectsParser#deep_key_search, which gives a sorted list of all properties in the JSONL document, including those used in objects which themselves are properties.

They don't do anything particularly interesting for extract_1.jsonl, the first because that file is essentially a list of 4,999 items all of which have the same keys. This file isn't a particularly interesting case for the second method either, because while a number of properties have object values, those values only have "id" and "text" properties.

But many JSON documents are branching structures, for which summary data might give one an idea where to start.